### PR TITLE
Add tiers "About" page support and stubs

### DIFF
--- a/_includes/tiers-about.liquid
+++ b/_includes/tiers-about.liquid
@@ -1,0 +1,11 @@
+---
+layout: base.liquid
+permalink: "{{ page.filePathStem }}/../about.html"
+---
+<h1>About the “{{ tiersTitle }}” tiers</h1>
+
+<main>
+    {{ content }}
+</main>
+
+<a href="./">Go back to the tiers</a>

--- a/src/tiers/chris-nolan-movies/_about.md
+++ b/src/tiers/chris-nolan-movies/_about.md
@@ -1,0 +1,10 @@
+---
+layout: base.liquid
+permalink: "{{ page.filePathStem }}/../about.html"
+---
+# About the “{{ tiersTitle }}” tiers
+
+TODO
+
+[Go back to the tiers](./)
+

--- a/src/tiers/chris-nolan-movies/_about.md
+++ b/src/tiers/chris-nolan-movies/_about.md
@@ -1,10 +1,6 @@
 ---
-layout: base.liquid
-permalink: "{{ page.filePathStem }}/../about.html"
+layout: tiers-about.liquid
 ---
-# About the “{{ tiersTitle }}” tiers
 
-TODO
-
-[Go back to the tiers](./)
+TODO NOLAN
 

--- a/src/tiers/kids-shows/_about.md
+++ b/src/tiers/kids-shows/_about.md
@@ -1,0 +1,10 @@
+---
+layout: base.liquid
+permalink: "{{ page.filePathStem }}/../about.html"
+---
+# About the “{{ tiersTitle }}” tiers
+
+TODO
+
+[Go back to the tiers](./)
+

--- a/src/tiers/kids-shows/_about.md
+++ b/src/tiers/kids-shows/_about.md
@@ -1,10 +1,6 @@
 ---
-layout: base.liquid
-permalink: "{{ page.filePathStem }}/../about.html"
+layout: tiers-about.liquid
 ---
-# About the “{{ tiersTitle }}” tiers
 
-TODO
-
-[Go back to the tiers](./)
+TODO KIDS
 

--- a/src/tiers/tiers.liquid
+++ b/src/tiers/tiers.liquid
@@ -10,6 +10,8 @@ permalink: tiers/{{ pagination.items[0].tiersId }}/index.html
     <h1>{{ tiers.tiersTitle }}</h1>
 </header>
 
+<p><a href="about.html">About these tiers</a></p>
+
 {% renderTemplate "webc" %}
 <tiers-link></tiers-link>
 {% endrenderTemplate %}


### PR DESCRIPTION
Resolves #13.

This changeset doesn't add the actual "about" content for the tiers, but that can be handled as part of writing the actual tiers content.